### PR TITLE
[Refactor] 테이블 컴포넌트 기본 html 태그로 변경

### DIFF
--- a/components/trade/MarketCodeSelector.jsx
+++ b/components/trade/MarketCodeSelector.jsx
@@ -30,7 +30,7 @@ function MarketCodeSelector({
       alignItems="center"
       justifyContent="space-between"
     >
-      <DescriptionTypo sx={{ mb: 1 }}>마켓 코드</DescriptionTypo>
+      <DescriptionTypo fontSize={'1.5rem'}>마켓 코드</DescriptionTypo>
       <Select name="marketcode" onChange={handleMarketCode} value={currentCode}>
         {marketCodes
           ? marketCodes.map(code => (

--- a/components/trade/orderbook/OrderbookTableAlone.jsx
+++ b/components/trade/orderbook/OrderbookTableAlone.jsx
@@ -1,34 +1,13 @@
 import { memo } from 'react';
 import {
-  AloneTableCell,
   DescriptionTypo,
   NGTypo,
   PriceTypo,
   TableContainer,
   theme,
 } from '@/defaultTheme';
-import {
-  Box,
-  Paper,
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableRow,
-  LinearProgress,
-} from '@mui/material';
-import { SubTitle } from '@/defaultTheme';
-import { globalColors } from '@/globalColors';
-import { styled } from '@mui/system';
+import { Box, Paper, LinearProgress } from '@mui/material';
 import MarketCodeSelector from '@/components/trade/MarketCodeSelector';
-
-const AskTableCell = styled(TableCell)(() => ({
-  paddingLeft: '3rem',
-}));
-
-const BidTableCell = styled(TableCell)(() => ({
-  paddingRight: '3rem',
-}));
 
 function OrderTableAlone({
   orderbookData,
@@ -52,15 +31,6 @@ function OrderTableAlone({
         },
       }}
     >
-      <SubTitle
-        sx={{
-          [theme.breakpoints.down('md')]: {
-            mb: '1rem',
-          },
-        }}
-      >
-        실시간 오더북
-      </SubTitle>
       <MarketCodeSelector
         currentCode={currentCode}
         setCurrentCode={setCurrentCode}
@@ -87,67 +57,56 @@ function OrderTableAlone({
               paddingBottom: 1,
             }}
           >
-            <Box sx={{ display: 'flex' }}>
-              <NGTypo>마켓 티커 </NGTypo>
-              <NGTypo fontWeight={'bold'}>
-                {' '}
-                : {orderbookData.targetMarketCode}
-              </NGTypo>
-            </Box>
             <NGTypo>총 매도 물량 : {orderbookData.total_ask_size}</NGTypo>
             <NGTypo>총 매수 물량 : {orderbookData.total_bid_size}</NGTypo>
           </Box>
-          <Table display="flex">
-            <TableHead>
-              <TableRow>
-                <AloneTableCell align="center">
+          <table className="table">
+            <thead>
+              <tr>
+                <th>
                   <DescriptionTypo>매도 물량</DescriptionTypo>
-                </AloneTableCell>
-                <AloneTableCell align="center">
+                </th>
+                <th>
                   <DescriptionTypo>가격</DescriptionTypo>
-                </AloneTableCell>
-                <AloneTableCell align="center">
+                </th>
+                <th>
                   <DescriptionTypo>매수 물량</DescriptionTypo>
-                </AloneTableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
               {[...orderbookData.orderbook_units]
                 .reverse()
                 .map((element, index) => (
-                  <TableRow key={`${element.ask_price}${index}`}>
-                    <AskTableCell
-                      sx={{ backgroundColor: globalColors.color_ask['200'] }}
-                    >
-                      <PriceTypo fontSize={12} align="right">
+                  <tr key={`${element.ask_price}${index}`}>
+                    <td className="td ask-volume">
+                      <PriceTypo fontSize={12}>
                         {Number(element.ask_size)}
                       </PriceTypo>
-                    </AskTableCell>
-                    <AskTableCell>
-                      <PriceTypo align="center" fontSize={12}>
+                    </td>
+                    <td className="td td-center">
+                      <PriceTypo fontSize={12}>
                         {Number(element.ask_price).toLocaleString()}
                       </PriceTypo>
-                    </AskTableCell>
-                    <AskTableCell>-</AskTableCell>
-                  </TableRow>
+                    </td>
+                    <td className="td">-</td>
+                  </tr>
                 ))}
               {[...orderbookData.orderbook_units].map((element, index) => (
-                <TableRow key={`${element.bid_price}${index}`}>
-                  <BidTableCell sx={{ textAlign: 'right' }}>-</BidTableCell>
-                  <BidTableCell>
-                    <PriceTypo align="center" fontSize={12}>
+                <tr key={`${element.bid_price}${index}`}>
+                  <td className="td">-</td>
+                  <td className="td">
+                    <PriceTypo fontSize={12}>
                       {Number(element.bid_price).toLocaleString()}
                     </PriceTypo>
-                  </BidTableCell>
-                  <BidTableCell
-                    sx={{ backgroundColor: globalColors.color_bid['200'] }}
-                  >
+                  </td>
+                  <td className="td bid-volume">
                     <PriceTypo fontSize={12}>{element.bid_size}</PriceTypo>
-                  </BidTableCell>
-                </TableRow>
+                  </td>
+                </tr>
               ))}
-            </TableBody>
-          </Table>
+            </tbody>
+          </table>
         </TableContainer>
       ) : (
         <LinearProgress color="primary" />

--- a/components/trade/tradeHistory/TradeTableAlone.jsx
+++ b/components/trade/tradeHistory/TradeTableAlone.jsx
@@ -1,29 +1,12 @@
 import { memo } from 'react';
 import {
-  AloneTableCell,
-  DescriptionTypo,
-  PriceTypo,
-  SubTitle,
   TableContainer,
+  DescriptionTypo,
   theme,
+  HeadTypo,
 } from '@/defaultTheme';
-import { styled } from '@mui/system';
-import {
-  Table,
-  TableBody,
-  TableHead,
-  TableRow,
-  Box,
-  LinearProgress,
-} from '@mui/material';
+import { Box, LinearProgress } from '@mui/material';
 import MarketCodeSelector from '@/components/trade/MarketCodeSelector';
-
-const HeadTypo = styled(DescriptionTypo)(() => ({
-  fontSize: '1.25rem',
-  '@media (max-width:900px)': {
-    fontSize: '0.688rem',
-  },
-}));
 
 function TradeTableAlone({
   isConnected,
@@ -47,15 +30,6 @@ function TradeTableAlone({
         },
       }}
     >
-      <SubTitle
-        sx={{
-          [theme.breakpoints.down('md')]: {
-            mb: '1rem',
-          },
-        }}
-      >
-        실시간 거래내역
-      </SubTitle>
       <MarketCodeSelector
         currentCode={currentCode}
         setCurrentCode={setCurrentCode}
@@ -69,50 +43,42 @@ function TradeTableAlone({
       </Box>
       <TableContainer>
         {tradeData && isConnected ? (
-          <Table>
-            <TableHead>
-              <TableRow>
-                <AloneTableCell align="center">
+          <table className="table">
+            <thead>
+              <tr>
+                <th>
                   <HeadTypo>코인</HeadTypo>
-                </AloneTableCell>
-                <AloneTableCell align="center">
+                </th>
+                <th>
                   <HeadTypo>체결 ID</HeadTypo>
-                </AloneTableCell>
-                <AloneTableCell align="center">
-                  <HeadTypo>체결 시간</HeadTypo>
-                </AloneTableCell>
-                <AloneTableCell align="center">
+                </th>
+                <th>
+                  <HeadTypo>체결 시간(UTC)</HeadTypo>
+                </th>
+                <th>
                   <HeadTypo>ASK/BID</HeadTypo>
-                </AloneTableCell>
-                <AloneTableCell align="center">
+                </th>
+                <th>
                   <HeadTypo>체결 가격</HeadTypo>
-                </AloneTableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {tradeData.slice().map((element, index) => (
-                <TableRow key={`${index}${element.trade_time}`}>
-                  <AloneTableCell align="center">
-                    {element.market}
-                  </AloneTableCell>
-                  <AloneTableCell align="center">
-                    {Number(element.sequential_id)}
-                  </AloneTableCell>
-                  <AloneTableCell align="center">
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {tradeData.map((element, index) => (
+                <tr key={`${index}${element.trade_time}`}>
+                  <td className="td-center">{element.market}</td>
+                  <td className="td-center">{Number(element.sequential_id)}</td>
+                  <td className="td-center">
                     {element.trade_date_utc} {element.trade_time_utc}
-                  </AloneTableCell>
-                  <AloneTableCell align="center">
-                    {element.ask_bid}
-                  </AloneTableCell>
-                  <AloneTableCell align="center">
-                    <PriceTypo fontSize={11}>
-                      {Number(element.prev_closing_price).toLocaleString()}
-                    </PriceTypo>
-                  </AloneTableCell>
-                </TableRow>
+                  </td>
+                  <td className="td-center">{element.ask_bid}</td>
+                  <td className="td-center">
+                    {Number(element.prev_closing_price).toLocaleString()}
+                  </td>
+                </tr>
               ))}
-            </TableBody>
-          </Table>
+            </tbody>
+          </table>
         ) : (
           <LinearProgress color="primary" />
         )}

--- a/defaultTheme.js
+++ b/defaultTheme.js
@@ -153,18 +153,6 @@ export const LogoTypo = styled(Typography)(() => ({
 
 /**
  * 스티키 테이블 헤더 셀 스타일을 정의하는 컴포넌트입니다.
- * @param {object} theme - MUI 테마 객체
- * @returns {import('@mui/system').StyledComponent<import('@mui/material').TableCellProps>}
- */
-export const StyledTableCell = styled(TableCell)(({ theme }) => ({
-  backgroundColor: theme.palette.primary.main,
-  position: 'sticky',
-  top: 0,
-  zIndex: 100,
-}));
-
-/**
- * 스티키 테이블 헤더 셀 스타일을 정의하는 컴포넌트입니다.
  * @returns {import('@mui/system').StyledComponent<import('@mui/material').BoxProps>}
  */
 export const FlexCenterBox = styled(Box)(() => ({
@@ -183,6 +171,28 @@ export const TableContainer = styled(Box)(() => ({
   backgroundColor: globalColors.white,
   borderRadius: '0.5rem',
   overflow: 'hidden',
+  '@media (max-width:900px)': {
+    maxWidth: '50rem',
+    marginLeft: '1rem',
+    marginRight: '1rem',
+  },
+  '@media (max-width:600px)': {
+    maxWidth: '30rem',
+    marginLeft: '1rem',
+    marginRight: '1rem',
+  },
+}));
+
+/**
+ * 스티키 테이블 헤더 셀 스타일을 정의하는 컴포넌트입니다.
+ * @param {object} theme - MUI 테마 객체
+ * @returns {import('@mui/system').StyledComponent<import('@mui/material').TableCellProps>}
+ */
+export const StyledTableCell = styled(TableCell)(({ theme }) => ({
+  backgroundColor: theme.palette.primary.main,
+  position: 'sticky',
+  top: 0,
+  zIndex: 100,
 }));
 
 /**
@@ -192,4 +202,16 @@ export const TableContainer = styled(Box)(() => ({
 export const AloneTableCell = styled(TableCell)(() => ({
   paddingLeft: '3rem',
   paddingRight: '3rem',
+  textAlign: 'center',
+}));
+
+/**
+ * 테이블 헤드 타이포그래피
+ * @returns {import('@mui/system').StyledComponent<import('@mui/material').TypographyProps>}
+ */
+export const HeadTypo = styled(DescriptionTypo)(() => ({
+  fontSize: '1.25rem',
+  '@media (max-width:900px)': {
+    fontSize: '0.688rem',
+  },
 }));

--- a/pages/trade/tradeHistory.jsx
+++ b/pages/trade/tradeHistory.jsx
@@ -51,7 +51,12 @@ function TradeHistory({ marketCodes }) {
                   prevItem => prevItem.sequential_id === item.sequential_id,
                 ),
             );
-            return [...prevTradeData, ...newData];
+
+            const updatedTradeData = [...newData.reverse(), ...prevTradeData]
+              .slice(0, 20)
+              .reverse();
+
+            return updatedTradeData;
           });
         } catch (error) {
           console.error('실시간 거래 내역 데이터 다운로드 에러: ', error);

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,3 +1,16 @@
+::-webkit-scrollbar {
+  width: 8px;
+}
+::-webkit-scrollbar-track {
+  background: #f1f1f1;
+}
+::-webkit-scrollbar-thumb {
+  background: #888;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: #555;
+}
+
 /* 오뮤 예쁨 */
 @font-face {
     font-family: 'omyu_pretty';
@@ -68,15 +81,68 @@ body {
   font-family: 'NEXON Lv1 Gothic Low OTF', Arial, sans-serif;
 }
 
-::-webkit-scrollbar {
-  width: 8px;
+.table {
+  max-width: '62.5rem';
+  margin-top:  '1rem';
+  border-radius: '0.5rem';
+  background-color: #fff;
+  border-collapse: collapse;
+  overflow: hidden;
 }
-::-webkit-scrollbar-track {
-  background: #f1f1f1;
+
+thead {
+  background-color: #ff63ac;
 }
-::-webkit-scrollbar-thumb {
-  background: #888;
+
+.table th,
+.table td {
+  border-bottom: 1px solid #ddd; 
+  text-align: center; 
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
 }
-::-webkit-scrollbar-thumb:hover {
-  background: #555;
+
+.table th {
+  font-weight: bold; 
+  font-size: 1.2rem;
+  background-color: #ff63ac;
+  color: #fff;
+}
+
+.td-center {
+  padding: 1.5rem;
+}
+
+.ask-volume {
+  padding-left: 3rem;
+  padding-right: 0rem;
+  background-color: #b6f5fa;
+  text-align: right; 
+}
+
+.bid-volume {
+  padding-right: 3rem;
+  padding-left: 0rem;
+  background-color: #f5bfd0;
+  text-align: left; 
+}
+
+@media (max-width: 900px) {
+  .table {
+    width: 100%; 
+    max-width: 100%;
+    font-size: 0.8rem; 
+  }
+}
+
+@media (max-width: 600px) {
+  .table th,
+  .table td {
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+  }
+  
+  .table th {
+    font-size: 1rem
+  }
 }


### PR DESCRIPTION
실시간 오더북, 실시간 거래 내역 ->
MUI의 테이블 관련 컴포넌트를 html 기본 태그로 대체하고 globals.css에서 스타일 적용하는 방식으로 변경