### PR TITLE
[Refactor] 차트 페이지 성능 개선 2차

### DIFF
--- a/components/trade/chart/marketDetail/MarketDetailGrid.jsx
+++ b/components/trade/chart/marketDetail/MarketDetailGrid.jsx
@@ -1,5 +1,4 @@
-import { useEffect, useState } from 'react';
-import { globalColors } from '@/globalColors';
+import { useMemo, useEffect, useState } from 'react';
 import { LinearProgress } from '@mui/material';
 import { useSelector } from 'react-redux';
 import axios from 'axios';
@@ -15,10 +14,15 @@ export default function MarketDetailGrid({ marketCodes }) {
   const [isLoading, setIsLoading] = useState(true);
   const [ticker, setTicker] = useState([]);
   const code = useSelector(state => state.chart.code);
-  const marketCodeMap = {};
-  marketCodes.forEach(item => {
-    marketCodeMap[item.market] = item.korean_name;
-  });
+  const intervalTime = useSelector(state => state.chart.intervalTime);
+
+  const codeMap = useMemo(() => {
+    const map = {};
+    marketCodes.forEach(item => {
+      map[item.market] = item.korean_name;
+    });
+    return map;
+  }, [marketCodes]);
 
   useEffect(() => {
     if (code) {
@@ -35,10 +39,10 @@ export default function MarketDetailGrid({ marketCodes }) {
       };
 
       fetchTicker();
-      const interval = setInterval(fetchTicker, 3000);
+      const interval = setInterval(fetchTicker, intervalTime);
       return () => clearInterval(interval);
     }
-  }, [code]);
+  }, [code, intervalTime]);
 
   const numColor =
     ticker && ticker.signed_change_rate === 0
@@ -50,10 +54,6 @@ export default function MarketDetailGrid({ marketCodes }) {
   if (isLoading) return <LinearProgress color="primary" />;
 
   return (
-    <MarketDetailTable
-      marketCodeMap={marketCodeMap}
-      ticker={ticker}
-      numColor={numColor}
-    />
+    <MarketDetailTable codeMap={codeMap} ticker={ticker} numColor={numColor} />
   );
 }

--- a/components/trade/chart/marketDetail/MarketDetailTable.jsx
+++ b/components/trade/chart/marketDetail/MarketDetailTable.jsx
@@ -16,12 +16,12 @@ function SubIndicator({ label, value, valueStyle }) {
   );
 }
 
-export default function MarketDetailTable({ marketCodeMap, ticker, numColor }) {
+export default function MarketDetailTable({ codeMap, ticker, numColor }) {
   return (
     <div className="h-[6.25rem] border-dashed border-[0.313rem] border-main bg-white box-border">
       <div className="flex flex-wrap ml-[0.125rem] gap-0.5 items-end">
         <span className="font-ng font-bold text-[1.25rem]">
-          {marketCodeMap[ticker.market]}
+          {codeMap[ticker.market]}
         </span>
         <span className="font-ng text-[0.938rem] text-right">
           {ticker.market}

--- a/components/trade/chart/marketList/MarketListGrid.jsx
+++ b/components/trade/chart/marketList/MarketListGrid.jsx
@@ -1,4 +1,5 @@
-import { memo, useEffect, useState } from 'react';
+import { memo, useMemo, useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
 import { LinearProgress } from '@mui/material';
 import axios from 'axios';
 import MarketListTable from './MarketListTable';
@@ -12,10 +13,15 @@ import MarketListTable from './MarketListTable';
 function MarketListGrid({ marketCodes }) {
   const [isLoading, setIsLoading] = useState(true);
   const [tickers, setTickers] = useState([]);
-  const marketCodeMap = {};
-  marketCodes.forEach(item => {
-    marketCodeMap[item.market] = item.korean_name;
-  });
+  const intervalTime = useSelector(state => state.chart.intervalTime);
+
+  const codeMap = useMemo(() => {
+    const map = {};
+    marketCodes.forEach(item => {
+      map[item.market] = item.korean_name;
+    });
+    return map;
+  }, [marketCodes]);
 
   useEffect(() => {
     if (marketCodes) {
@@ -36,15 +42,15 @@ function MarketListGrid({ marketCodes }) {
       };
 
       fetchTickers();
-      const interval = setInterval(fetchTickers, 3000);
+      const interval = setInterval(fetchTickers, intervalTime);
       return () => clearInterval(interval);
     }
-  }, [marketCodes]);
+  }, [marketCodes, intervalTime]);
 
   if (isLoading) {
     return <LinearProgress color="primary" />;
   }
 
-  return <MarketListTable tickers={tickers} marketCodeMap={marketCodeMap} />;
+  return <MarketListTable tickers={tickers} codeMap={codeMap} />;
 }
 export default memo(MarketListGrid);

--- a/components/trade/chart/marketList/MarketListTable.jsx
+++ b/components/trade/chart/marketList/MarketListTable.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 import {
   setCode,
@@ -22,7 +22,7 @@ const StyledTableContainer = styled(TableContainer)(() => ({
   backgroundColor: globalColors.white,
 }));
 
-export default function MarketListTable({ marketCodeMap, tickers }) {
+export default function MarketListTable({ codeMap, tickers }) {
   const [searchKeyword, setSearchKeyword] = useState('');
 
   const dispatch = useDispatch();
@@ -34,17 +34,18 @@ export default function MarketListTable({ marketCodeMap, tickers }) {
     dispatch(setCurrPrice(currPrice));
   };
 
-  const filteredTickers = tickers.filter(ticker => {
-    const marketName =
-      marketCodeMap[ticker.code] || marketCodeMap[ticker.market];
-    return (
-      (marketName && marketName.includes(searchKeyword.toLowerCase())) ||
-      (ticker.code &&
-        ticker.code.toLowerCase().includes(searchKeyword.toLowerCase())) ||
-      (ticker.market &&
-        ticker.market.toLowerCase().includes(searchKeyword.toLowerCase()))
-    );
-  });
+  const filteredTickers = useMemo(() => {
+    return tickers.filter(ticker => {
+      const marketName = codeMap[ticker.code] || codeMap[ticker.market];
+      return (
+        (marketName && marketName.includes(searchKeyword.toLowerCase())) ||
+        (ticker.code &&
+          ticker.code.toLowerCase().includes(searchKeyword.toLowerCase())) ||
+        (ticker.market &&
+          ticker.market.toLowerCase().includes(searchKeyword.toLowerCase()))
+      );
+    });
+  }, [tickers, searchKeyword, codeMap]);
 
   return (
     <>
@@ -102,8 +103,7 @@ export default function MarketListTable({ marketCodeMap, tickers }) {
                       fontWeight={'bold'}
                       sx={{ maxWidth: '5rem' }}
                     >
-                      {marketCodeMap[ticker.code] ||
-                        marketCodeMap[ticker.market]}
+                      {codeMap[ticker.code] || codeMap[ticker.market]}
                     </NGTypo>
                     <NGTypo fontSize={10} color={globalColors.market_code}>
                       {ticker.code || ticker.market}

--- a/components/trade/chart/orderbook/OrderbookGrid.jsx
+++ b/components/trade/chart/orderbook/OrderbookGrid.jsx
@@ -13,6 +13,7 @@ function OrderbookGrid() {
   const [isLoading, setIsLoading] = useState(true);
   const [orderbookData, setOrderbookData] = useState([]);
   const code = useSelector(state => state.chart.code);
+  const intervalTime = useSelector(state => state.chart.intervalTime);
 
   useEffect(() => {
     if (code) {
@@ -29,10 +30,10 @@ function OrderbookGrid() {
       };
 
       fetchOrderbookData();
-      const interval = setInterval(fetchOrderbookData, 3000);
+      const interval = setInterval(fetchOrderbookData, intervalTime);
       return () => clearInterval(interval);
     }
-  }, [code]);
+  }, [code, intervalTime]);
 
   if (isLoading) {
     return <LinearProgress color="primary" />;

--- a/components/trade/chart/orderbook/OrderbookTable.jsx
+++ b/components/trade/chart/orderbook/OrderbookTable.jsx
@@ -1,10 +1,10 @@
-import { useState, useCallback, useEffect, memo } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { globalColors } from '@/globalColors';
 import { LinearProgress } from '@mui/material';
 import { PriceTypo, HeadTypo } from '@/defaultTheme';
 
-const OrderbookTable = memo(function OrderbookTable({ orderbookData }) {
+export default function OrderbookTable({ orderbookData }) {
   const rate = useSelector(state => state.chart.rate);
   const prevPrice = useSelector(state => state.chart.prevPrice);
   const [numColor, setNumColor] = useState(
@@ -48,7 +48,7 @@ const OrderbookTable = memo(function OrderbookTable({ orderbookData }) {
 
   return (
     <>
-      {orderbookData.orderbook_units && (
+      {orderbookData?.orderbook_units && (
         <div className="w-full h-[25rem] bg-white overflow-y-auto">
           <table className="w-full border-collapse">
             <thead className="sticky top-0 z-10 bg-main">
@@ -162,6 +162,4 @@ const OrderbookTable = memo(function OrderbookTable({ orderbookData }) {
       )}
     </>
   );
-});
-
-export default OrderbookTable;
+}

--- a/components/trade/chart/tradeHistory/TradeHistoryGrid.jsx
+++ b/components/trade/chart/tradeHistory/TradeHistoryGrid.jsx
@@ -13,6 +13,7 @@ function TradeHistoryGrid() {
   const [isLoading, setIsLoading] = useState(true);
   const [tradeData, setTradeData] = useState([]);
   const code = useSelector(state => state.chart.code);
+  const intervalTime = useSelector(state => state.chart.intervalTime);
 
   useEffect(() => {
     if (code) {
@@ -45,10 +46,10 @@ function TradeHistoryGrid() {
       };
 
       fetchTradeData();
-      const interval = setInterval(fetchTradeData, 3000);
+      const interval = setInterval(fetchTradeData, intervalTime);
       return () => clearInterval(interval);
     }
-  }, [code]);
+  }, [code, intervalTime]);
 
   if (isLoading) {
     return <LinearProgress color="primary" />;

--- a/components/trade/chart/tradeHistory/TradeTable.jsx
+++ b/components/trade/chart/tradeHistory/TradeTable.jsx
@@ -18,7 +18,7 @@ export default function TradeTable({ tradeData }) {
 
   return (
     <div className="max-w-[62.5rem] h-[25rem] overflow-auto bg-white">
-      {tradeData && (
+      {tradeData?.length > 0 && (
         <table className="w-full">
           <thead className="sticky top-0 z-10 bg-main">
             <tr>
@@ -38,7 +38,7 @@ export default function TradeTable({ tradeData }) {
           </thead>
           <tbody>
             {tradeData.slice().map(data => (
-              <tr key={data.sequential_id * Math.random()}>
+              <tr key={data.sequential_id}>
                 <td className="table-cell border-b-[0.063rem] border-color:rgba(224, 224, 224, 1)] border-solid text-center">
                   <NGTypo fontSize={12}>
                     {timestampToTime(data.timestamp)}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9195,6 +9195,28 @@
         "node": ">= 10"
       }
     },
+    "node_modules/webpack-bundle-analyzer/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/webpack-sources": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
@@ -9483,28 +9505,6 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/pages/trade/chart.jsx
+++ b/pages/trade/chart.jsx
@@ -31,7 +31,7 @@ const OpenModalButton = styled(Button)(() => ({
   '&:hover': { color: theme.palette.secondary.light },
 }));
 
-const DynamicChart = dynamic(
+const HighStockChart = dynamic(
   () => import('@/components/trade/chart/HighChartGrid'),
   {
     ssr: false,
@@ -41,7 +41,7 @@ const DynamicChart = dynamic(
 function HighChartGrid() {
   return (
     <div>
-      <DynamicChart />
+      <HighStockChart />
     </div>
   );
 }

--- a/utils/redux/chartSlice.js
+++ b/utils/redux/chartSlice.js
@@ -2,6 +2,7 @@ import { createSlice } from '@reduxjs/toolkit';
 
 const initialState = {
   code: 'KRW-BTC',
+  intervalTime: 5000,
   rate: 0,
   prevPrice: null,
   currPrice: null,
@@ -21,6 +22,9 @@ const chartSlice = createSlice({
   reducers: {
     setCode: (state, action) => {
       state.code = action.payload;
+    },
+    setCallTime: (state, action) => {
+      state.intervalTime = action.payload;
     },
     setRate: (state, action) => {
       state.rate = action.payload;


### PR DESCRIPTION
- MarketListGrid, MarketDetailGrid: 해시코드맵 useMemo 적용
- MarketListTable: 필터링된 티커  useMemo 적용
- TradeTable: key에 랜덤 삭제
- OrderbookTable: memo 삭제
- REST API 호출 그리드 컴포넌트들의 intervalTime을 전역 상태로 설정