### PR TITLE
[Fix] lighthouse 성능 측정 테스트를 위한 ProtectedRoute 비활성화 구문 추가

### DIFF
--- a/components/ProtectedRoute.jsx
+++ b/components/ProtectedRoute.jsx
@@ -9,6 +9,8 @@ export default function ProtectedRoute({ children }) {
   const [userId, setUserId] = useState(null);
 
   useEffect(() => {
+    if (process.env.NEXT_PUBLIC_DISABLE_PROTECTED === 'true') return; // 테스트시 비활성화
+
     const storedUserId = localStorage.getItem('userId');
     setUserId(storedUserId);
 


### PR DESCRIPTION
성능 테스트시 lighthouse의 측정을 위해 NEXT_PUBLIC_DISABLE_PROTECTED 추가하기